### PR TITLE
Open multiline selections properly in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Add these lines to the workspace settings:
 ```
 
 ## TODO
-* Support Multiline Selections
 * Open Repository
 * Open Pull Request related to the file
 

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,14 +1,14 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
 
 export default function blameCommand() {
   baseCommand('blame', { github: formatGitHubBlameUrl, bitbucket: formatBitbucketBlameUrl });
 }
 
-export function formatGitHubBlameUrl(remote: string, branch: string, filePath: string, line?: number): string {
-  return `${remote}/blame/${branch}/${filePath}${formatGitHubLinePointer(line)}`;
+export function formatGitHubBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/blame/${branch}/${filePath}${formatGitHubLinePointer(lines)}`;
 }
 
-export function formatBitbucketBlameUrl(remote: string, branch: string, filePath: string, line?: number): string {
-  return `${remote}/annotate/${branch}/${filePath}${formatBitbucketLinePointer(filePath, line)}`;
+export function formatBitbucketBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/annotate/${branch}/${filePath}${formatBitbucketLinePointer(filePath, lines)}`;
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,14 +1,14 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
 
 export default function fileCommand() {
   baseCommand('file', { github: formatGitHubFileUrl, bitbucket: formatBitbucketFileUrl });
 }
 
-export function formatGitHubFileUrl(remote: string, branch: string, filePath: string, line?: number): string {
-  return `${remote}/blob/${branch}/${filePath}${formatGitHubLinePointer(line)}`;
+export function formatGitHubFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/blob/${branch}/${filePath}${formatGitHubLinePointer(lines)}`;
 }
 
-export function formatBitbucketFileUrl(remote: string, branch: string, filePath: string, line?: number): string {
-  return `${remote}/src/${branch}/${filePath}${formatBitbucketLinePointer(filePath, line)}`;
+export function formatBitbucketFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/src/${branch}/${filePath}${formatBitbucketLinePointer(filePath, lines)}`;
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,14 +1,14 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, BRANCH_URL_SEP } from './common';
+import { baseCommand, BRANCH_URL_SEP, SelectedLines } from './common';
 
 export default function historyCommand() {
   baseCommand('history', { github: formatGitHubHistoryUrl, bitbucket: formatBitbucketHistoryUrl });
 }
 
-export function formatGitHubHistoryUrl(remote: string, branch: string, filePath: string, line: number): string {
+export function formatGitHubHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {
   return `${remote}/commits/${branch}/${filePath}`;
 }
 
-export function formatBitbucketHistoryUrl(remote: string, branch: string, filePath: string, line: number): string {
+export function formatBitbucketHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {
   return `${remote}/history-node/${branch}/${filePath}`;
 }

--- a/test/blame.test.ts
+++ b/test/blame.test.ts
@@ -1,9 +1,20 @@
 import * as assert from 'assert';
 import * as blame from '../src/blame';
+import { SelectedLines } from '../src/common';
 
 suite('blameCommand # formatGitHubBlameUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = blame.formatGitHubBlameUrl('https://remote.url', 'master', 'rel/path/to/file.js', 10);
+    const results = blame.formatGitHubBlameUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://remote.url/blame/master/rel/path/to/file.js#L10');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitHubBlameUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://remote.url/blame/master/rel/path/to/file.js#L10:L20');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitHubBlameUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
     assert.equal(results, 'https://remote.url/blame/master/rel/path/to/file.js#L10');
   });
 
@@ -15,7 +26,17 @@ suite('blameCommand # formatGitHubBlameUrl', () => {
 
 suite('blameCommand # formatBitbucketBlameUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = blame.formatBitbucketBlameUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', 10);
+    const results = blame.formatBitbucketBlameUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://bitbucket.org/some/repo/annotate/master/rel/path/to/file.js#file.js-10');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatBitbucketBlameUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://bitbucket.org/some/repo/annotate/master/rel/path/to/file.js#file.js-10:20');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatBitbucketBlameUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
     assert.equal(results, 'https://bitbucket.org/some/repo/annotate/master/rel/path/to/file.js#file.js-10');
   });
 

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -115,18 +115,23 @@ suite('#prepareQuickPickItems', () => {
   const formatters = { github: () => '', bitbucket: () => '' };
   suite('if current branch and master branch are equal', () => {
     test('should return only 1 item if there is only 1 remote', () => {
-      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', 10, [['https://rem'], ['master']]);
+      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10 }, [['https://rem'], ['master']]);
+      assert.equal(result.length, 1);
+    });
+
+    test('should return only 1 item if there is only 1 remote', () => {
+      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem'], ['master']]);
       assert.equal(result.length, 1);
     });
 
     test('should return number of quick pick items equal to number of remotes', () => {
-      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', 10, [['https://rem', 'https://rem2'], ['master']]);
+      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['master']]);
       assert.equal(result.length, 2);
     });
   });
 
   suite('if current branch and master branch are not equal', () => {
-    const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', 10, [['https://rem', 'https://rem2'], ['feat', 'master']]);
+    const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['feat', 'master']]);
 
     test('should merge quick pick items for current branch and master branch', () => {
       assert.equal(result.length, 4);

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -3,7 +3,15 @@ import * as file from '../src/file';
 
 suite('fileCommand # formatGitHubFileUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = file.formatGitHubFileUrl('https://remote.url', 'master', 'rel/path/to/file.js', 10);
+    const results = file.formatGitHubFileUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://remote.url/blob/master/rel/path/to/file.js#L10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitHubFileUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://remote.url/blob/master/rel/path/to/file.js#L10:L20');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitHubFileUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
     assert.equal(results, 'https://remote.url/blob/master/rel/path/to/file.js#L10');
   });
   test('should format strings for quick pick view', () => {
@@ -14,7 +22,15 @@ suite('fileCommand # formatGitHubFileUrl', () => {
 
 suite('fileCommand # formatBitbucketFileUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', 10);
+    const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js#file.js-10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js#file.js-10:20');
+  });
+    test('should format strings for quick pick view', () => {
+    const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
     assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js#file.js-10');
   });
   test('should format strings for quick pick view', () => {

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -3,14 +3,14 @@ import * as history from '../src/history';
 
 suite('historyCommand # formatGitHubHistoryUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = history.formatGitHubHistoryUrl('https://remote.url', 'master', 'rel/path/to/file.js', 10);
+    const results = history.formatGitHubHistoryUrl('https://remote.url', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
     assert.equal(results, 'https://remote.url/commits/master/rel/path/to/file.js');
   });
 });
 
 suite('historyCommand # formatBitbucketHistoryUrl', () => {
   test('should format strings for quick pick view', () => {
-    const results = history.formatBitbucketHistoryUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', 10);
+    const results = history.formatBitbucketHistoryUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
     assert.equal(results, 'https://bitbucket.org/some/repo/history-node/master/rel/path/to/file.js');
   });
 });


### PR DESCRIPTION
Add handling such that when multiple lines are selected in the editor, the responding github/bitbucket urls will properly reflect the selected lines instead of the first selected line.