### PR TITLE
Multi-root support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
     "version": "1.6.0",
     "publisher": "sysoev",
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.18.0"
     },
     "categories": [
         "Other"
     ],
     "keywords": [
+        "multi-root ready",
         "vscode",
         "github",
         "bitbucket",
@@ -49,11 +50,13 @@
             "title": "Which branch is default in repository.",
             "properties": {
                 "openInGitHub.defaultBranch": {
+                    "scope": "resource",
                     "type": "string",
                     "default": "master",
                     "description": "Controls which branch will be treated as default."
                 },
                 "openInGitHub.defaultRemote": {
+                    "scope": "resource",
                     "type": "string",
                     "default": "origin",
                     "description": "Controls which remote will be treated as default."

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,12 +31,13 @@ export function baseCommand(commandName: string, formatters: Formatters) {
   }
 
   const filePath = window.activeTextEditor.document.fileName;
+  const fileUri = window.activeTextEditor.document.uri;
   const lineStart = window.activeTextEditor.selection.start.line + 1;
   const lineEnd = window.activeTextEditor.selection.end.line + 1;
   const selectedLines = { start: lineStart, end: lineEnd };
-  const defaultBranch = workspace.getConfiguration('openInGitHub').get<string>('defaultBranch') || 'master';
-  const defaultRemote = workspace.getConfiguration('openInGitHub').get<string>('defaultRemote') || 'origin';
-  const projectPath = workspace.rootPath;
+  const defaultBranch = workspace.getConfiguration('openInGitHub', fileUri).get<string>('defaultBranch') || 'master';
+  const defaultRemote = workspace.getConfiguration('openInGitHub', fileUri).get<string>('defaultRemote') || 'origin';
+  const projectPath = path.dirname(filePath);
 
   return getRepoRoot(exec, projectPath)
     .then(repoRootPath => {


### PR DESCRIPTION
Hi @d4rkr00t,

This PR adds support for multiple root folders in the same VS Code window. That requires VS Code 1.18.0 or later.

Cheers,

Christof
