### PR TITLE
Open specific commit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ When editing a file, use the command palette (cmd + shift + p / ctrl + shift + p
 * Works with Bitbucket.
 * Configurable default branch.
 * Open multiline selection.
+* Open the current revision.
 
 ## Configuration
 
@@ -39,6 +40,7 @@ Add these lines to the workspace settings:
   ...
   "openInGitHub.defaultBranch": "master",
   "openInGitHub.defaultRemote": "origin",
+  "openInGitHub.includeCurrentRevision": true,
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add these lines to the workspace settings:
   ...
   "openInGitHub.defaultBranch": "master",
   "openInGitHub.defaultRemote": "origin",
-  "openInGitHub.includeCurrentRevision": true,
+  "openInGitHub.excludeCurrentRevision": false,
   ...
 }
 ```

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
                     "default": "origin",
                     "description": "Controls which remote will be treated as default."
                 },
-                "openInGitHub.includeCurrentRevision": {
+                "openInGitHub.excludeCurrentRevision": {
                     "scope": "resource",
                     "type": "boolean",
                     "default": false,
-                    "description": "Determines whether to suggest a URL for the current revision (commit SHA)"
+                    "description": "Determines whether to disable URL suggestions for the current revision (commit SHA)"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
                     "type": "string",
                     "default": "origin",
                     "description": "Controls which remote will be treated as default."
+                },
+                "openInGitHub.includeCurrentRevision": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Determines whether to suggest a URL for the current revision (commit SHA)"
                 }
             }
         }

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -111,6 +111,27 @@ suite('#getBranches', () => {
   });
 });
 
+suite('#getCurrentRevision', () => {
+  const mockRevisionResult = 'abc123\n';
+
+  test('should return current revision, with newline stripped', done => {
+    common
+      .getCurrentRevision((cmd, opts, cb) => cb(null, mockRevisionResult, null), '')
+      .then((branch) => {
+        assert.deepEqual(branch, 'abc123');
+        done();
+      })
+      .catch(done);
+  });
+
+  test('should be rejected if error occurred', done => {
+    common
+      .getCurrentRevision((cmd, opts, cb) => cb(null, mockRevisionResult, 'error'), '')
+      .then(done)
+      .catch(() => done());
+  });
+});
+
 suite('#prepareQuickPickItems', () => {
   const formatters = { github: () => '', bitbucket: () => '' };
   suite('if current branch and master branch are equal', () => {

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -86,7 +86,7 @@ suite('#getBranches', () => {
 
   test('should return current branch', done => {
     common
-      .getBranches((cmd, opts, cb) => cb(null, mockBranchResult, null), '', 'dev')
+      .getBranches((cmd, opts, cb) => cb(null, mockBranchResult, null), '', 'dev', true)
       .then((branch) => {
         assert.deepEqual(branch, ['sysoev/SERP-42779', 'dev']);
         done();
@@ -96,7 +96,7 @@ suite('#getBranches', () => {
 
   test('should return empty string if there aren`t any remotes with the name of current branch', done => {
     common
-      .getBranches((cmd, opts, cb) => cb(null, mockBranchResultNoRemotes, null), '', 'dev')
+      .getBranches((cmd, opts, cb) => cb(null, mockBranchResultNoRemotes, null), '', 'dev', true)
       .then((branch) => {
         !branch.length && done();
       })


### PR DESCRIPTION
This Pull Request allows users to specify `"openInGitHub.includeCurrentRevision": true` in their config. If set, a URL will be offered in the picklist that will create a deep link to a file at a specific revision.

See https://github.com/d4rkr00t/vscode-open-in-github/issues/10 for some discussion/rationale.

This works on both GitHub and BitBucket.

![image](https://user-images.githubusercontent.com/2362668/42324020-45ce8878-8062-11e8-8771-15dbcbca1667.png)
