### PR TITLE
Allow customizing max buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Add these lines to the workspace settings:
   ...
   "openInGitHub.defaultBranch": "master",
   "openInGitHub.defaultRemote": "origin",
+  "openInGithub.maxBuffer": 512000
   ...
 }
 ```

--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
                     "type": "string",
                     "default": "origin",
                     "description": "Controls which remote will be treated as default."
+                },
+                "openInGithub.maxBuffer": {
+                  "scope": "resource",
+                  "type": "number",
+                  "default": "204800",
+                  "description": "Controls the `maxBuffer` allowed when executing git commands."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
                 "openInGithub.maxBuffer": {
                   "scope": "resource",
                   "type": "number",
-                  "default": "204800",
+                  "default": 204800,
                   "description": "Controls the `maxBuffer` allowed when executing git commands."
                 }
             }

--- a/src/common.ts
+++ b/src/common.ts
@@ -195,9 +195,12 @@ export function formatRemotes(remotes: string[]) : string[] {
  *
  * @return {Promise<String>}
  */
-export function getBranches(exec, projectPath: string, defaultBranch: string, maxBuffer: number) : Promise<string[]> {
+export function getBranches(exec, projectPath: string, defaultBranch: string, maxBuffer?: number) : Promise<string[]> {
   return new Promise((resolve, reject) => {
-    exec('git branch --no-color -a', { cwd: projectPath, maxBuffer }, (error, stdout, stderr) => {
+    const options: any = { cwd: projectPath };
+    if (maxBuffer) options.maxBuffer = maxBuffer;
+
+    exec('git branch --no-color -a', options, (error, stdout, stderr) => {
       if (stderr || error) return reject(stderr || error);
 
       const getCurrentBranch = R.compose(

--- a/src/common.ts
+++ b/src/common.ts
@@ -37,7 +37,7 @@ export function baseCommand(commandName: string, formatters: Formatters) {
   const selectedLines = { start: lineStart, end: lineEnd };
   const defaultBranch = workspace.getConfiguration('openInGitHub', fileUri).get<string>('defaultBranch') || 'master';
   const defaultRemote = workspace.getConfiguration('openInGitHub', fileUri).get<string>('defaultRemote') || 'origin';
-  const maxBuffer = workspace.getConfiguration('openInGithub', fileUri).get<number>('maxBuffer') || 200 * 1024;
+  const maxBuffer = workspace.getConfiguration('openInGithub', fileUri).get<number>('maxBuffer') || undefined;
   const projectPath = path.dirname(filePath);
 
   return getRepoRoot(exec, projectPath)


### PR DESCRIPTION
On large repos (or repos with a lot of branches), `git branch --no-color -a` can exceed the max buffer size and cause `exec` to fail. This allows for customizing the `maxBuffer` parameter for those workspaces.

I tested on this repo and the repo I was seeing the issue. The extension works again 😅 