### PR TITLE
Add bitbucket server support

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,24 @@
                     "type": "string",
                     "default": "origin",
                     "description": "Controls which remote will be treated as default."
+                },
+                "openInGitHub.repositoryType": {
+                    "scope": "resource",
+                    "type":"string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",
+                        "github",
+                        "bitbucket",
+                        "bitbucket-server"
+                    ],
+                    "enumDescriptions": [
+                        "Auto detection of repository type",
+                        "Github",
+                        "Bitbucket",
+                        "Bitbucket Server (uses /projects/<project>/repos/<repo> repository URL scheme)"
+                    ],
+                    "description": "Defines type of repository"
                 }
             }
         }

--- a/src/bitbucketServer.ts
+++ b/src/bitbucketServer.ts
@@ -1,0 +1,27 @@
+import { SelectedLines } from './common';
+
+export function formatBitbucketServerUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  const re = /(https\:\/\/[^\/]+)\/([^\/]+)\/([^\/]+)/;
+  const matches = remote.match(re);
+  if (matches.length != 4) {
+    return '';
+  }
+
+  const host = matches[1];
+  const project = matches[2];
+  const repo = matches[3];
+  const branchRef = encodeURIComponent(`refs/heads/${branch}`);
+  const linePointer = formatBitbucketServerLinePointer(lines);
+
+  return `${host}/projects/${project}/repos/${repo}/browse/${filePath}?at=${branchRef}${linePointer}`;
+}
+
+function formatBitbucketServerLinePointer(lines?: SelectedLines): string {
+  if (!lines || !lines.start) {
+    return '';
+  }
+  let linePointer = `#${lines.start}`;
+  if (lines.end && lines.end != lines.start) linePointer += `-${lines.end}`;
+
+  return linePointer;
+}

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,8 +1,9 @@
 import { window, workspace } from 'vscode';
 import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
+import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function blameCommand() {
-  baseCommand('blame', { github: formatGitHubBlameUrl, bitbucket: formatBitbucketBlameUrl });
+  baseCommand('blame', { github: formatGitHubBlameUrl, bitbucket: formatBitbucketBlameUrl, bitbucketServer: formatBitbucketServerUrl });
 }
 
 export function formatGitHubBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,8 +1,9 @@
 import { window, workspace } from 'vscode';
 import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
+import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function fileCommand() {
-  baseCommand('file', { github: formatGitHubFileUrl, bitbucket: formatBitbucketFileUrl });
+  baseCommand('file', { github: formatGitHubFileUrl, bitbucket: formatBitbucketFileUrl, bitbucketServer: formatBitbucketServerUrl });
 }
 
 export function formatGitHubFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,8 +1,9 @@
 import { window, workspace } from 'vscode';
 import { baseCommand, BRANCH_URL_SEP, SelectedLines } from './common';
+import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function historyCommand() {
-  baseCommand('history', { github: formatGitHubHistoryUrl, bitbucket: formatBitbucketHistoryUrl });
+  baseCommand('history', { github: formatGitHubHistoryUrl, bitbucket: formatBitbucketHistoryUrl, bitbucketServer: formatBitbucketServerUrl });
 }
 
 export function formatGitHubHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {

--- a/test/bitbucketServer.test.ts
+++ b/test/bitbucketServer.test.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+import { formatBitbucketServerUrl } from '../src/bitbucketServer';
+
+suite('#formatBitbucketServerFileUrl', () => {
+  test('should format strings for quick pick view', () => {
+    const results = formatBitbucketServerUrl('https://bitbucket.org/my-project/my-repo', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://bitbucket.org/projects/my-project/repos/my-repo/browse/rel/path/to/file.js?at=refs%2Fheads%2Fmaster#10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = formatBitbucketServerUrl('https://bitbucket.org/my-project/my-repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://bitbucket.org/projects/my-project/repos/my-repo/browse/rel/path/to/file.js?at=refs%2Fheads%2Fmaster#10-20');
+  });
+    test('should format strings for quick pick view', () => {
+    const results = formatBitbucketServerUrl('https://bitbucket.org/my-project/my-repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
+    assert.equal(results, 'https://bitbucket.org/projects/my-project/repos/my-repo/browse/rel/path/to/file.js?at=refs%2Fheads%2Fmaster#10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = formatBitbucketServerUrl('https://bitbucket.org/my-project/my-repo', 'master', 'rel/path/to/file.js');
+    assert.equal(results, 'https://bitbucket.org/projects/my-project/repos/my-repo/browse/rel/path/to/file.js?at=refs%2Fheads%2Fmaster');
+  });
+});

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -112,26 +112,26 @@ suite('#getBranches', () => {
 });
 
 suite('#prepareQuickPickItems', () => {
-  const formatters = { github: () => '', bitbucket: () => '' };
+  const formatters = { github: () => '', bitbucket: () => '', bitbucketServer: () => '' };
   suite('if current branch and master branch are equal', () => {
     test('should return only 1 item if there is only 1 remote', () => {
-      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10 }, [['https://rem'], ['master']]);
+      const result = common.prepareQuickPickItems('auto', formatters, 'test-command', 'file.js', { start: 10 }, [['https://rem'], ['master']]);
       assert.equal(result.length, 1);
     });
 
     test('should return only 1 item if there is only 1 remote', () => {
-      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem'], ['master']]);
+      const result = common.prepareQuickPickItems('auto', formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem'], ['master']]);
       assert.equal(result.length, 1);
     });
 
     test('should return number of quick pick items equal to number of remotes', () => {
-      const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['master']]);
+      const result = common.prepareQuickPickItems('auto', formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['master']]);
       assert.equal(result.length, 2);
     });
   });
 
   suite('if current branch and master branch are not equal', () => {
-    const result = common.prepareQuickPickItems(formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['feat', 'master']]);
+    const result = common.prepareQuickPickItems('auto', formatters, 'test-command', 'file.js', { start: 10, end: 20 }, [['https://rem', 'https://rem2'], ['feat', 'master']]);
 
     test('should merge quick pick items for current branch and master branch', () => {
       assert.equal(result.length, 4);


### PR DESCRIPTION
Added support for [Bitbucket Server](https://www.atlassian.com/software/bitbucket/server) which uses different repository url scheme `https/bb.my-team.ru/projects/<project>/repos/<repo>`.
Also I've added a `repositoryType` option which obviously can be used to specify repository type for workspace. Default value `'auto'` fallbacks to previously used detection mechanism.