### PR TITLE
fix: escape branch names in github url

### DIFF
--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,5 +1,5 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function blameCommand() {
@@ -7,7 +7,7 @@ export default function blameCommand() {
 }
 
 export function formatGitHubBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
-  return `${remote}/blame/${branch}/${filePath}${formatGitHubLinePointer(lines)}`;
+  return `${remote}/blame/${formatGithubBranchName(branch)}/${filePath}${formatGitHubLinePointer(lines)}`;
 }
 
 export function formatBitbucketBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {

--- a/src/common.ts
+++ b/src/common.ts
@@ -289,6 +289,10 @@ export function prepareQuickPickItems(repositoryType: string, formatters: Format
   return processBranches(branches);
 }
 
+export function formatGithubBranchName(branch) {
+  return branch.split('/').map(c => encodeURIComponent(c)).join('/');
+}
+
 /**
  * Returns true if remote is butbicket.
  */

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,5 +1,5 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, SelectedLines } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function fileCommand() {
@@ -7,7 +7,7 @@ export default function fileCommand() {
 }
 
 export function formatGitHubFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
-  return `${remote}/blob/${branch}/${filePath}${formatGitHubLinePointer(lines)}`;
+  return `${remote}/blob/${formatGithubBranchName(branch)}/${filePath}${formatGitHubLinePointer(lines)}`;
 }
 
 export function formatBitbucketFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,5 +1,5 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, BRANCH_URL_SEP, SelectedLines } from './common';
+import { baseCommand, formatGithubBranchName, SelectedLines } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function historyCommand() {
@@ -7,7 +7,7 @@ export default function historyCommand() {
 }
 
 export function formatGitHubHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {
-  return `${remote}/commits/${branch}/${filePath}`;
+  return `${remote}/commits/${formatGithubBranchName(branch)}/${filePath}`;
 }
 
 export function formatBitbucketHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -18,6 +18,10 @@ suite('fileCommand # formatGitHubFileUrl', () => {
     const results = file.formatGitHubFileUrl('https://remote.url', 'master', 'rel/path/to/file.js');
     assert.equal(results, 'https://remote.url/blob/master/rel/path/to/file.js');
   });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitHubFileUrl('https://remote.url', 'feature/#foo', 'rel/path/to/file.js');
+    assert.equal(results, 'https://remote.url/blob/feature/%23foo/rel/path/to/file.js');
+  });
 });
 
 suite('fileCommand # formatBitbucketFileUrl', () => {


### PR DESCRIPTION
Fixed to escape branch names if they include special characters like:

'foo#bar' -> 'foo%23bar'
'foo/#bar' -> 'foo/%23bar

I couldn't find any specifications about how github urls
should be encoded, though.

I'm afraid I don't know much about bitbucket's url.