### PR TITLE
Use dash instead of colon for GitHub line pointer

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -313,7 +313,7 @@ export function formatGitHubLinePointer(lines?: SelectedLines): string {
   }
 
   let linePointer = `#L${lines.start}`;
-  if (lines.end && lines.end != lines.start) linePointer += `:L${lines.end}`;
+  if (lines.end && lines.end != lines.start) linePointer += `-L${lines.end}`;
 
   return linePointer;
 }


### PR DESCRIPTION
Even though both : and - characters work to get a proper URL, when copying a permalink with ":" character denoting the line range, GitHub will not show the code inline in the comment but the link will instead be shown as a regular link.

For example, this link will show an inline preview of the code:

```
https://github.com/d4rkr00t/vscode-open-in-github/blob/6b85f479a59ddd687f5de752bc46c51fc8381e20/src/common.ts#L310-L313
```

https://github.com/d4rkr00t/vscode-open-in-github/blob/6b85f479a59ddd687f5de752bc46c51fc8381e20/src/common.ts#L310-L313

...but this link will not, even though the highlight works on the GitHub page:

```
https://github.com/d4rkr00t/vscode-open-in-github/blob/6b85f479a59ddd687f5de752bc46c51fc8381e20/src/common.ts#L310:L313
```

https://github.com/d4rkr00t/vscode-open-in-github/blob/6b85f479a59ddd687f5de752bc46c51fc8381e20/src/common.ts#L310:L313

---

I had been mystified why the code links in my pull requests didn't show the code inline, and then figured out it was about `:` vs `-` 