### PR TITLE
Fix regression in vscode functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Determines whether to disable URL suggestions for the current revision (commit SHA)"
+                },
+                "openInGithub.unsetGitDir": {
+                    "scope":"resource",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Execute `unset GIT_DIR` before all git commands. Vscode provides this env variable which breaks many git commands when run in subdirectories. Disable if you are setting this value yourself."
                 }
             }
         }

--- a/src/common.ts
+++ b/src/common.ts
@@ -22,12 +22,12 @@ export interface SelectedLines {
  * Returns the exec command prefixed with `unset GIT_DIR` if the unsetGitDir option is set.
  *
  * @param {Function} exec
- * @param {Function} unsetGitDir
+ * @param {Boolean} unsetGitDir
  *
  * @return {Function}
  */
-export function wrapExec(exec, unsetGitDir: Function) {
-  return unsetGitDir() ? (command, opts, cb) => exec(`unset GIT_DIR; ${command}`, opts, cb) : exec;
+export function wrapExec(exec, unsetGitDir: boolean) {
+  return unsetGitDir ? (command, opts, cb) => exec(`unset GIT_DIR; ${command}`, opts, cb) : exec;
 }
 
 /**
@@ -53,7 +53,7 @@ export function baseCommand(commandName: string, formatters: Formatters) {
   const defaultRemote = workspace.getConfiguration('openInGitHub', fileUri).get<string>('defaultRemote') || 'origin';
   const maxBuffer = workspace.getConfiguration('openInGithub', fileUri).get<number>('maxBuffer') || undefined;
   const excludeCurrentRevision = workspace.getConfiguration('openInGitHub').get<boolean>('excludeCurrentRevision') || false;
-  const unsetGitDir = () => workspace.getConfiguration('openInGithub', fileUri).get<boolean>('unsetGitDir');
+  const unsetGitDir = workspace.getConfiguration('openInGithub', fileUri).get<boolean>('unsetGitDir');
   const exec = wrapExec(childProcessExec, unsetGitDir);
 
   const repositoryType = config.get<string>('repositoryType');

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,11 +27,7 @@ export interface SelectedLines {
  * @return {Function}
  */
 export function wrapExec(exec, unsetGitDir: Function) {
-  return R.ifElse(
-    unsetGitDir,
-    (command, opts, cb) => exec(`unset GIT_DIR; ${command}`, opts, cb),
-    exec,
-  );
+  return unsetGitDir() ? (command, opts, cb) => exec(`unset GIT_DIR; ${command}`, opts, cb) : exec;
 }
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -80,7 +80,6 @@ export function baseCommand(commandName: string, formatters: Formatters) {
  */
 export function getRepoRoot(exec, workspacePath: string) : Promise<string> {
   return new Promise((resolve, reject) => {
-    console.log(workspacePath);
     exec('git rev-parse --show-toplevel', { cwd: workspacePath }, (error, stdout, stderr) => {
       if (stderr || error) return reject(stderr || error);
       resolve(stdout.trim());

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -166,3 +166,21 @@ suite('#prepareQuickPickItems', () => {
     });
   });
 });
+
+suite('#wrapExec', () => {
+  const exec = (command, opts, cb) => command;
+
+  suite('if unsetGitDir returns true', () => {
+    const unsetGitDir = () => true;
+    test('should call the wrapped command', () => {
+      assert.equal('unset GIT_DIR; do a thing', common.wrapExec(exec, unsetGitDir)('do a thing', null, null));
+    });
+  })
+
+  suite('if unsetGitDir returns false', () => {
+    const unsetGitDir = () => false;
+    test('should call the unwrapped command', () => {
+      assert.equal('do a thing', common.wrapExec(exec, unsetGitDir)('do a thing', null, null));
+    });
+  })
+});

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -170,15 +170,15 @@ suite('#prepareQuickPickItems', () => {
 suite('#wrapExec', () => {
   const exec = (command, opts, cb) => command;
 
-  suite('if unsetGitDir returns true', () => {
-    const unsetGitDir = () => true;
+  suite('if unsetGitDir is true', () => {
+    const unsetGitDir = true;
     test('should call the wrapped command', () => {
       assert.equal('unset GIT_DIR; do a thing', common.wrapExec(exec, unsetGitDir)('do a thing', null, null));
     });
   })
 
-  suite('if unsetGitDir returns false', () => {
-    const unsetGitDir = () => false;
+  suite('if unsetGitDir is false', () => {
+    const unsetGitDir = false;
     test('should call the unwrapped command', () => {
       assert.equal('do a thing', common.wrapExec(exec, unsetGitDir)('do a thing', null, null));
     });


### PR DESCRIPTION
Vscode has started setting the env var `GIT_DIR`. This causes issues for integrated terminals, and extensions which execute git commands on subdirectories.

This can be tested quite easily.

Executing the following command produces different results in vscode and an external terminal.

```bash
mkdir test_git_repo
cd test_git_repo
git init
mkdir sub_dir
cd sub_dir
git status
```

This PR introduces a fix for that issue, which is simply executing `unset GIT_DIR` before every git command. I think its conceivable that someone specifically sets this env var themselves, so I've also added an option to disable this functionality.

Finally, I've added a quick error message for a (previously) unhandled promise rejection.

Open issue here: https://github.com/d4rkr00t/vscode-open-in-github/issues/25

Additional details can be seen here: https://github.com/DonJayamanne/gitHistoryVSCode/issues/233