### PR TITLE
Fix urls for multiline selections to Gitlab repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,13 +69,15 @@
                         "auto",
                         "github",
                         "bitbucket",
-                        "bitbucket-server"
+                        "bitbucket-server",
+                        "gitlab"
                     ],
                     "enumDescriptions": [
                         "Auto detection of repository type",
                         "Github",
                         "Bitbucket",
-                        "Bitbucket Server (uses /projects/<project>/repos/<repo> repository URL scheme)"
+                        "Bitbucket Server (uses /projects/<project>/repos/<repo> repository URL scheme)",
+                        "Gitlab"
                     ],
                     "description": "Defines type of repository"
                 },

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,9 +1,14 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines, formatGitlabLinePointer } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function blameCommand() {
-  baseCommand('blame', { github: formatGitHubBlameUrl, bitbucket: formatBitbucketBlameUrl, bitbucketServer: formatBitbucketServerUrl });
+  baseCommand('blame', {
+    github: formatGitHubBlameUrl,
+    bitbucket: formatBitbucketBlameUrl,
+    bitbucketServer: formatBitbucketServerUrl,
+    gitlab: formatGitlabBlameUrl,
+  });
 }
 
 export function formatGitHubBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
@@ -12,4 +17,8 @@ export function formatGitHubBlameUrl(remote: string, branch: string, filePath: s
 
 export function formatBitbucketBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
   return `${remote}/annotate/${branch}/${filePath}${formatBitbucketLinePointer(filePath, lines)}`;
+}
+
+export function formatGitlabBlameUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/blame/${formatGithubBranchName(branch)}/${filePath}${formatGitlabLinePointer(lines)}`;
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,9 +1,14 @@
 import { window, workspace } from 'vscode';
-import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines } from './common';
+import { baseCommand, formatBitbucketLinePointer, formatGitHubLinePointer, formatGithubBranchName, SelectedLines, formatGitlabLinePointer } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function fileCommand() {
-  baseCommand('file', { github: formatGitHubFileUrl, bitbucket: formatBitbucketFileUrl, bitbucketServer: formatBitbucketServerUrl });
+  baseCommand('file', {
+    github: formatGitHubFileUrl,
+    bitbucket: formatBitbucketFileUrl,
+    bitbucketServer: formatBitbucketServerUrl,
+    gitlab: formatGitlabFileUrl,
+  });
 }
 
 export function formatGitHubFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
@@ -12,4 +17,8 @@ export function formatGitHubFileUrl(remote: string, branch: string, filePath: st
 
 export function formatBitbucketFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
   return `${remote}/src/${branch}/${filePath}${formatBitbucketLinePointer(filePath, lines)}`;
+}
+
+export function formatGitlabFileUrl(remote: string, branch: string, filePath: string, lines?: SelectedLines): string {
+  return `${remote}/blob/${formatGithubBranchName(branch)}/${filePath}${formatGitlabLinePointer(lines)}`;
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -3,7 +3,12 @@ import { baseCommand, formatGithubBranchName, SelectedLines } from './common';
 import { formatBitbucketServerUrl } from './bitbucketServer';
 
 export default function historyCommand() {
-  baseCommand('history', { github: formatGitHubHistoryUrl, bitbucket: formatBitbucketHistoryUrl, bitbucketServer: formatBitbucketServerUrl });
+  baseCommand('history', {
+    github: formatGitHubHistoryUrl,
+    bitbucket: formatBitbucketHistoryUrl,
+    bitbucketServer: formatBitbucketServerUrl,
+    gitlab: formatGitHubHistoryUrl,
+  });
 }
 
 export function formatGitHubHistoryUrl(remote: string, branch: string, filePath: string, lines: SelectedLines): string {

--- a/test/blame.test.ts
+++ b/test/blame.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 import * as blame from '../src/blame';
-import { SelectedLines } from '../src/common';
 
 suite('blameCommand # formatGitHubBlameUrl', () => {
   test('should format strings for quick pick view', () => {
@@ -43,5 +42,27 @@ suite('blameCommand # formatBitbucketBlameUrl', () => {
   test('should format strings for quick pick view', () => {
     const results = blame.formatBitbucketBlameUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js');
     assert.equal(results, 'https://bitbucket.org/some/repo/annotate/master/rel/path/to/file.js');
+  });
+});
+
+suite('blameCommand # formatGitlabBlameUrl', () => {
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitlabBlameUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blame/master/rel/path/to/file.js#L10');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitlabBlameUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blame/master/rel/path/to/file.js#L10-20');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitlabBlameUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blame/master/rel/path/to/file.js#L10');
+  });
+
+  test('should format strings for quick pick view', () => {
+    const results = blame.formatGitlabBlameUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js');
+    assert.equal(results, 'https://gitlab.com/test/repo/blame/master/rel/path/to/file.js');
   });
 });

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -135,7 +135,7 @@ suite('#getCurrentRevision', () => {
 });
 
 suite('#prepareQuickPickItems', () => {
-  const formatters = { github: () => '', bitbucket: () => '', bitbucketServer: () => '' };
+  const formatters = { github: () => '', bitbucket: () => '', bitbucketServer: () => '', gitlab: () => '' };
   suite('if current branch and master branch are equal', () => {
     test('should return only 1 item if there is only 1 remote', () => {
       const result = common.prepareQuickPickItems('auto', formatters, 'test-command', 'file.js', { start: 10 }, [['https://rem'], ['master']]);

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -33,12 +33,35 @@ suite('fileCommand # formatBitbucketFileUrl', () => {
     const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
     assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js#file.js-10:20');
   });
-    test('should format strings for quick pick view', () => {
+  test('should format strings for quick pick view', () => {
     const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
     assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js#file.js-10');
   });
   test('should format strings for quick pick view', () => {
     const results = file.formatBitbucketFileUrl('https://bitbucket.org/some/repo', 'master', 'rel/path/to/file.js');
     assert.equal(results, 'https://bitbucket.org/some/repo/src/master/rel/path/to/file.js');
+  });
+});
+
+suite('fileCommand # formatGitlabFileUrl', () => {
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitlabFileUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blob/master/rel/path/to/file.js#L10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitlabFileUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 20 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blob/master/rel/path/to/file.js#L10-20');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitlabFileUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js', { start: 10, end: 10 });
+    assert.equal(results, 'https://gitlab.com/test/repo/blob/master/rel/path/to/file.js#L10');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitlabFileUrl('https://gitlab.com/test/repo', 'master', 'rel/path/to/file.js');
+    assert.equal(results, 'https://gitlab.com/test/repo/blob/master/rel/path/to/file.js');
+  });
+  test('should format strings for quick pick view', () => {
+    const results = file.formatGitlabFileUrl('https://gitlab.com/test/repo', 'feature/#foo', 'rel/path/to/file.js');
+    assert.equal(results, 'https://gitlab.com/test/repo/blob/feature/%23foo/rel/path/to/file.js');
   });
 });


### PR DESCRIPTION
The Github format for these (`L10-L20`) _almost_ works, but gitlab chokes on the second `L`. The correct format for Gitlab is `L10-20`. I've added a gitlab formatter for the `Formatters` interface, although in practice it reuses all Github functionality except for these line descriptors. 

🍻 