### PR TITLE
Utilise a bundler for smaller builds and faster load times.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // we want to run npm
     "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
     "isWatching": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "problemMatcher": "$tsc-watch",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/build.js
+++ b/build.js
@@ -1,0 +1,25 @@
+const production = process.argv[2] === "--production";
+const watch = process.argv[2] === "--watch";
+
+require("esbuild")
+  .build({
+    entryPoints: ["./src/extension.ts"],
+    bundle: true,
+    outdir: "out",
+    external: ["vscode"],
+    format: "cjs",
+    sourcemap: !production,
+    minify: production,
+    platform: "node",
+    target: ["node12"],
+    watch: watch && {
+      onRebuild(error) {
+        if (error) console.error("watch build failed:", error);
+        else console.log("watch build succeeded");
+      }
+    }
+  })
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,6 +453,150 @@
                 "es6-promise": "^4.0.3"
             }
         },
+        "esbuild": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+            "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+            "dev": true,
+            "requires": {
+                "esbuild-android-arm64": "0.13.15",
+                "esbuild-darwin-64": "0.13.15",
+                "esbuild-darwin-arm64": "0.13.15",
+                "esbuild-freebsd-64": "0.13.15",
+                "esbuild-freebsd-arm64": "0.13.15",
+                "esbuild-linux-32": "0.13.15",
+                "esbuild-linux-64": "0.13.15",
+                "esbuild-linux-arm": "0.13.15",
+                "esbuild-linux-arm64": "0.13.15",
+                "esbuild-linux-mips64le": "0.13.15",
+                "esbuild-linux-ppc64le": "0.13.15",
+                "esbuild-netbsd-64": "0.13.15",
+                "esbuild-openbsd-64": "0.13.15",
+                "esbuild-sunos-64": "0.13.15",
+                "esbuild-windows-32": "0.13.15",
+                "esbuild-windows-64": "0.13.15",
+                "esbuild-windows-arm64": "0.13.15"
+            }
+        },
+        "esbuild-android-arm64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+            "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+            "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+            "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+            "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+            "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+            "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+            "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+            "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+            "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+            "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+            "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+            "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+            "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+            "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+            "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+            "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.13.15",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+            "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+            "dev": true,
+            "optional": true
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-open-in-github",
   "displayName": "Open In GitHub",
   "description": "Provides commands to quickly view the current file on GitHub.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "publisher": "sysoev",
   "engines": {
     "vscode": "^1.60.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.15.0",
   "publisher": "sysoev",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.60.0"
   },
   "categories": [
     "Other"
@@ -23,7 +23,7 @@
     "url": "https://github.com/d4rkr00t/vscode-open-in-github.git"
   },
   "bugs": "https://github.com/d4rkr00t/vscode-open-in-github/issues",
-  "main": "./out/src/extension",
+  "main": "./out/extension",
   "icon": "assets/icon.jpg",
   "activationEvents": [
     "onCommand:openInGithub.openInGitHubFile",
@@ -112,9 +112,9 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
-    "compile": "tsc -watch -p ./",
-    "build": "tsc -p ./",
+    "vscode:prepublish": "node ./build.js --production",
+    "compile": "node ./build.js",
+    "watch": "node ./build.js --watch",
     "lint:staged": "lint-staged --no-stash",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
@@ -122,11 +122,12 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.3",
     "@types/ramda": "^0.25.41",
-    "typescript": "^3.1.6",
-    "vscode": "^1.1.37",
+    "esbuild": "^0.13.15",
     "lint-staged": "^10.1.3",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "typescript": "^3.1.6",
+    "vscode": "^1.1.37"
   },
   "lint-staged": {
     "*.ts": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,11 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "out",
-        "lib": [
-            "es6"
-        ],
-        "sourceMap": true,
-        "rootDir": "."
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "sourceMap": true,
+    "rootDir": "."
+  },
+  "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
Previously: 278ms load time
Now: 15ms load time.

Previously: 22MB
Now 110KB

- This PR adds ESBuild to build the project down to a single js file. 
- The version has also been increased to cover ES2020.
- The tasks.json has had a schema update