### PR TITLE
Fix configuration typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add these lines to the workspace settings:
 
   
   // When enabled skips branch detection and always uses default branch.
-  "openInGitHub.alwaysUseDeafultBranch": false,
+  "openInGitHub.alwaysUseDefaultBranch": false,
 
   // Determines whether to disable URL suggestions for the current revision (commit SHA)
   "openInGitHub.excludeCurrentRevision": false,


### PR DESCRIPTION
Noticed a typo in the README that was preventing a copy/pasted configuration to take effect. With this change, folks can copy the configuration and it will work correctly.