### PR TITLE
Switch from `open` package to using `vscode.open` command.

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,7 +6,7 @@ require("esbuild")
     entryPoints: ["./src/extension.ts"],
     bundle: true,
     outdir: "./out",
-    external: ["vscode", "open"],
+    external: ["vscode"],
     format: "cjs",
     sourcemap: !production,
     minify: production,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "clipboardy": "^2.3.0",
-        "open": "^8.4.2",
         "ramda": "^0.25.0"
       },
       "devDependencies": {
@@ -729,14 +728,6 @@
       "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2169,30 +2160,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/open/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -3498,11 +3465,6 @@
         "clone": "^1.0.2"
       }
     },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -4481,26 +4443,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "open": {
-      "version": "8.4.2",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "dependencies": {
-        "is-wsl": {
-          "version": "2.2.0",
-          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-wsl/-/is-wsl-2.2.0.tgz",
-          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-          "requires": {
-            "is-docker": "^2.0.0"
-          }
-        }
       }
     },
     "os-shim": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
   },
   "dependencies": {
     "clipboardy": "^2.3.0",
-    "open": "^8.4.2",
     "ramda": "^0.25.0"
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,9 +2,9 @@ import { window, workspace, QuickPickItem } from "vscode";
 
 const exec = require("child_process").exec;
 const path = require("path");
-const open = require("open");
 const R = require("ramda");
 const clipboardy = require("clipboardy");
+import * as vscode from "vscode";
 
 export const BRANCH_URL_SEP = " — ";
 
@@ -537,7 +537,10 @@ export function showQuickPickWindow(quickPickList: QuickPickItem[]) {
  */
 export async function openQuickPickItem(item?: QuickPickItem) {
   if (!item) return;
-  return await open((item as any).url);
+  return await vscode.commands.executeCommand(
+    "vscode.open",
+    vscode.Uri.parse((item as any).url)
+  );
 }
 
 /**


### PR DESCRIPTION
The open command in VSCode's extension API supports choosing a browser (or browser launch options) via the `workbench.externalBrowser` setting. API reference: https://code.visualstudio.com/api/references/commands.

Without this change, the `open` package always uses the default browser determined by the OS. This _could_ be customized via the `app` argument (docs: https://www.npmjs.com/package/open). That could be useful if someone wants to customize this extension independent of the full VSCode editor, but I figured removing a dependency and reusing other editor settings would make more sense.

### Motivating usage

If the extension just uses my default OS browser, that has no launch arguments and uses my "personal profile" when I want to launch my "work profile". I can use this to open a different browser profile (controlled by launch args as indicated by [this guide](https://www.reddit.com/r/firefox/comments/s2k5tt/have_multiple_firefox_profile_and_taskbar_icons/)) if I set a script as my `externalBrowser`:

```jsonc
// vscode settings
"workbench.externalBrowser": "launch_firefox_work.vbs",
```

```vbs
' launch_firefox_work_.vbs
Set objShell = CreateObject("Wscript.Shell")
programFiles = objShell.ExpandEnvironmentStrings("%PROGRAMFILES%")
profileName = "Work"
strPath = """" & programFiles & "\Mozilla Firefox\firefox.exe" & """ --no-remote -P " & profileName & " " & WScript.Arguments(0)
objShell.Run strPath

' this could also be a .bat file but that shows a window whenever it runs
' the equivalent .bat file is simpler:
' "%PROGRAMFILES%\Mozilla Firefox\firefox.exe" --no-remote -P Work %1
```